### PR TITLE
fix/default-input

### DIFF
--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -8,7 +8,7 @@
       "type": "string",
       "description": "The URL from which the crawler will start to generate the llms.txt file.",
       "editor": "textfield",
-      "prefill": "https://docs.apify.com/"
+      "prefill": "https://docs.apify.com/cli/docs"
     },
     "maxCrawlDepth": {
       "title": "Max crawl depth",


### PR DESCRIPTION
Change default run `url`, so it crawls less pages and takes less time to remove the under maintenance flag